### PR TITLE
Revert "Bump highlight.js from 10.1.2 to 10.7.3 in /2021/public/apps/vuletube/submodules/voice-commander/voice-commander/src/typescript"

### DIFF
--- a/2021/public/apps/vuletube/submodules/voice-commander/voice-commander/src/typescript/package-lock.json
+++ b/2021/public/apps/vuletube/submodules/voice-commander/voice-commander/src/typescript/package-lock.json
@@ -3094,9 +3094,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.2.tgz",
+      "integrity": "sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==",
       "dev": true
     },
     "hmac-drbg": {


### PR DESCRIPTION
Reverts zlatnaspirala/maximumroulette-com#19